### PR TITLE
Adds Jenkins TAP compatible test durations

### DIFF
--- a/lib/tap-file.js
+++ b/lib/tap-file.js
@@ -40,7 +40,11 @@ function TapFile(runner) {
 
   });
 
-  runner.on('test end', function(){
+  runner.on('test end', function(test){
+    if (!isNaN(test.duration)) {
+        console.log('  ---\n  duration_ms: %d\n  ...', test.duration);
+        appendLine('  ---\n  duration_ms: ' + test.duration + '\n  ...');
+    } 
     ++n;
   });
 


### PR DESCRIPTION
This change adds a [TAP 13](https://testanything.org/tap-version-13-specification.html) YAML block per test that reports the duration when available. This format is compatible with the Jenkins [TAP Plugin](https://wiki.jenkins-ci.org/display/JENKINS/TAP+Plugin). 
